### PR TITLE
2.X + 3.0 compatibility

### DIFF
--- a/AuthCAS/AuthCAS.php
+++ b/AuthCAS/AuthCAS.php
@@ -1,6 +1,6 @@
 <?php
 
-class AuthCAS extends LimeSurvey\PluginManager\AuthPluginBase
+class AuthCAS extends AuthPluginBase
 {
 
     protected $storage = 'DbStorage';


### PR DESCRIPTION
- except 2.63 version, there are a shortcut for AuthPluginBase in [application/core/](https://github.com/LimeSurvey/LimeSurvey/blob/master/application/core/AuthPluginBase.php)
- `LimeSurvey\PluginManager\` work only for 3.0 and up version (see [2.73](https://github.com/LimeSurvey/LimeSurvey/blob/2.73/application/core/AuthPluginBase.php) version of same file)
- I didn't test plugin on 2.X and 3.X, but to have multi compat plugin, i always use this :)