### PR TITLE
Added afterUserAutoCreate PluginEvent.

### DIFF
--- a/AuthCAS/AuthCAS.php
+++ b/AuthCAS/AuthCAS.php
@@ -328,6 +328,12 @@ class AuthCAS extends LimeSurvey\PluginManager\AuthPluginBase
 
                         // read again user from newly created entry
                         $this->setAuthSuccess($oUser);
+
+						// fire afterAutoCreate event
+						$event = new PluginEvent('afterUserAutoCreate');
+						$event->set('username', $username);
+						App()->getPluginManager()->dispatchEvent($event);
+
                         return;
                     } else 
                     {
@@ -382,6 +388,12 @@ class AuthCAS extends LimeSurvey\PluginManager\AuthPluginBase
                         $permission->setPermissions($oUser->uid, 0, 'global', $this->api->getConfigKey('auth_cas_autocreate_permissions'), true);
                     }
                     $this->setAuthSuccess($oUser);
+
+					// fire afterAutoCreate event
+					$event = new PluginEvent('afterUserAutoCreate');
+					$event->set('username', $oUser->users_name);
+					App()->getPluginManager()->dispatchEvent($event);
+
                     return;
                 } else
                 {


### PR DESCRIPTION
I have added a PluginEvent "afterUserAutoCreate" so that other plugins can update user settings and permissions after the user is created.

I need to be able to do just that, but there is no guarantee that the limesurvey-cas newUserSession() will fire before my plugin's newUserSession().  The addition of this event hook would save me from having to duplicate parts of AuthCAS in my own code and simplify the rest of my plugin considerably.