### PR TITLE
Retrieve Required Info from Basic Authentication Attributes

### DIFF
--- a/AuthCAS/AuthCAS.php
+++ b/AuthCAS/AuthCAS.php
@@ -70,8 +70,9 @@ class AuthCAS extends AuthPluginBase
         ),
         'casMailAttr' => array(
             'type' => 'string',
-            'label' => 'CAS attribute for mail',
-            'default' => 'mail'
+            'label' => 'CAS attribute for mail (or @domain))',
+            'default' => 'mail',
+            'help' => 'If your CAS server doesn\'t return an email address attribute, specify the @domain, and it will be combined with the username.'
         ),
         'server' => array(
             'type' => 'string',

--- a/AuthCAS/AuthCAS.php
+++ b/AuthCAS/AuthCAS.php
@@ -435,8 +435,20 @@ class AuthCAS extends AuthPluginBase
                     // disable SSL validation of the CAS server
                     //phpCAS::setNoCasServerValidation();
                     $cas_fullname = phpCAS::getAttribute($this->get('casFullnameAttr'));
+
                     $cas_login = phpCAS::getAttribute($this->get('casLoginAttr'));
+                    if (empty($cas_login)) {
+                        $cas_login = phpCAS::getUser();
+                    }
+
                     $cas_mail = phpCAS::getAttribute($this->get('casMailAttr'));
+                    if (empty($cas_mail)) {
+                        // If attribute is empty, check if casMailAttr contains a @domain
+                        if (strpos($this->get('casMailAttr'), '@') == 0) {
+                            $cas_domain = $this->get('casMailAttr');
+                            $cas_mail = $cas_login . $cas_domain;
+                        }
+                    }
                 } catch (Exception $e)
                 {
                     $this->setAuthFailure(self::ERROR_USERNAME_INVALID);


### PR DESCRIPTION
This PR allows the plugin to work with a CAS server that doesn't send user attributes. It generates the email address by using the username and the email domain specified in casMailAttr.

![image](https://github.com/user-attachments/assets/ff4081df-a891-4c75-b4ae-eaa1cd00b6d6)

I've chosen to reuse `casMailAttr` instead of introducing a new parameter, but this could easily be adjusted. A new field could be added to handle cases where the `casMailAttr` returns an empty value from the server.

Fixes #27 